### PR TITLE
Fix broken link to mytinybalcony.com

### DIFF
--- a/index.html
+++ b/index.html
@@ -707,7 +707,7 @@
                             (or any other beverage of your choice).<br>
                             Let's grab a drink!</h1>
                             <div style="font-size:20px;">
-                                <a href="www.mytinybalcony.com"> 
+                                <a href="http://www.mytinybalcony.com"> 
                                     <span class="fa-stack fa-lg">
                                       <i class="fa fa-circle fa-stack-2x"></i>
                                       <i class="fa fa-coffee fa-stack-1x fa-inverse"></i>


### PR DESCRIPTION
HREF tag was using a relative URL causing the URL to be `http://{host}/www.mytinybalcony.com` rather than `http://www.mytinybalcony.com` as expected.